### PR TITLE
feat: add Serde Deserialize/Serialize optional traits

### DIFF
--- a/nosleep-types/Cargo.toml
+++ b/nosleep-types/Cargo.toml
@@ -14,3 +14,7 @@ keywords = ["nosleep", "powersave", "caffeine"]
 
 [dependencies]
 snafu = "0.7.0"
+serde = { version = "1.0.137", features = ["derive"], optional = true }
+
+[features]
+serde = ["dep:serde"]

--- a/nosleep-types/src/lib.rs
+++ b/nosleep-types/src/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NoSleepType {
     /// Prevents the display from dimming automatically.

--- a/nosleep/Cargo.toml
+++ b/nosleep/Cargo.toml
@@ -22,3 +22,6 @@ nosleep-nix = { path = "../nosleep-nix", version = "0.2.0-rc.1" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 nosleep-windows = { path = "../nosleep-windows", version = "0.2.0-rc.1" }
+
+[features]
+serde = ["nosleep-types/serde"]


### PR DESCRIPTION
It is best practice to include the Serialize/Deserialize traits from Serde, as it makes it a lot easier to work with the NoSleep types.

Source: https://rust-lang.github.io/api-guidelines/interoperability.html#data-structures-implement-serdes-serialize-deserialize-c-serde