### PR TITLE
fix: UnInhibit for KDE

### DIFF
--- a/nosleep-nix/src/lib.rs
+++ b/nosleep-nix/src/lib.rs
@@ -194,7 +194,7 @@ fn uninhibit_msg(api: &DBusAPI, handle: u32) -> dbus::Message {
         DBusAPI::FreeDesktopPowerApi => dbus::Message::call_with_args(
             "org.freedesktop.PowerManagement",
             "/org/freedesktop/PowerManagement/Inhibit",
-            "org.freedesktop.PowerManagment.Inhibit",
+            "org.freedesktop.PowerManagement.Inhibit",
             "UnInhibit",
             (handle,),
         ),


### PR DESCRIPTION
Fixes https://github.com/pevers/nosleep/issues/4

Fixes a small typo causing the UnInhibit message to panic on KDE desktops.