### PR TITLE
feat: simplify API (breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 Cross-platform library to block the power save function in the OS.
 
 ```rust
-use nosleep::{NoSleep, NoSleepType};
+use nosleep::{NoSleep, NoSleepTrait};
 let mut nosleep = NoSleep::new().unwrap();
 nosleep
-    .start(NoSleepType::PreventUserIdleDisplaySleep)
+    .prevent_display_sleep() // or prevent_system_sleep()
     .unwrap();
 std::thread::sleep(std::time::Duration::from_millis(180_000));
 nosleep.stop().unwrap(); // Not strictly needed

--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ nosleep
 std::thread::sleep(std::time::Duration::from_millis(180_000));
 nosleep.stop().unwrap(); // Not strictly needed
 ```
+
+## Supported Platforms
+
+| Platform | Status |
+|----------|--------|
+| Linux    | ✔️      |
+| macOS    | ✔️      |
+| Windows  | ✔️      |
+| iOS      | ⚠️      |
+| Android  | ❌      |

--- a/nosleep-mac-sys/Cargo.toml
+++ b/nosleep-mac-sys/Cargo.toml
@@ -4,11 +4,10 @@ description = "Block power save mode for macOS"
 authors = ["Peter Evers"]
 version = "0.2.1"
 edition = "2021"
-rust-version = "1.57"
 homepage = "https://github.com/pevers/nosleep-mac-sys"
 repository = "https://github.com/pevers/nosleep-mac-sys"
 license = "MIT"
-keywords = ["nosleep", "powersave", "caffeine"]
+keywords = ["nosleep", "powersave", "caffeine", "prevent-sleep", "prevent-display-lock", "prevent-system-lock"]
 readme = "README.md"
 
 build = "build.rs"
@@ -17,7 +16,7 @@ build = "build.rs"
 objc-foundation = "0.1.1"
 objc_id = "0.1.1"
 snafu = "0.7.0"
-nosleep-types = { path = "../nosleep-types", version = "0.2.0" }
+nosleep-types = { path = "../nosleep-types", version = "0.3.0" }
 
 [build-dependencies]
 cc = "1.0.73"

--- a/nosleep-mac-sys/Cargo.toml
+++ b/nosleep-mac-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nosleep-mac-sys"
 description = "Block power save mode for macOS"
 authors = ["Peter Evers"]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 homepage = "https://github.com/pevers/nosleep-mac-sys"
 repository = "https://github.com/pevers/nosleep-mac-sys"

--- a/nosleep-mac-sys/src/lib.rs
+++ b/nosleep-mac-sys/src/lib.rs
@@ -1,14 +1,12 @@
-//! Thin wrapper utility that provides utility
-//! methods to block and unblock the macOS power save mode
+//! Block the power save functionality on macOS
 
 #![allow(improper_ctypes)]
 
 use std::ops::Deref;
 
-use nosleep_types::NoSleepType;
+use nosleep_types::{NoSleepError, NoSleepTrait};
 use objc_foundation::{INSString, NSString};
-use objc_id::Id;
-use snafu::{prelude::*, Backtrace};
+
 mod sys {
     use objc_foundation::NSString;
 
@@ -19,102 +17,71 @@ mod sys {
             handle: *mut std::os::raw::c_uint,
         ) -> std::os::raw::c_int;
         pub fn stop(handle: std::os::raw::c_uint);
-        //pub fn isStarted(handle: std::os::raw::c_uint) -> bool;
     }
 }
 
-#[derive(Debug, Snafu)]
-pub enum Error {
-    #[snafu(display("Could not prevent power save mode for option {:?}", option))]
-    PreventPowerSaveMode {
-        option: NoSleepType,
-        backtrace: Backtrace,
-    },
-}
-
-pub type Result<T, E = Error> = std::result::Result<T, E>;
-
-fn nosleep_ns_string(nosleep_type: &NoSleepType) -> Id<NSString> {
-    match nosleep_type {
-        NoSleepType::PreventUserIdleDisplaySleep => {
-            NSString::from_str("PreventUserIdleDisplaySleep")
-        }
-        NoSleepType::PreventUserIdleSystemSleep => NSString::from_str("PreventUserIdleSystemSleep"),
-    }
-}
-
-/// Returned by [`NoSleep::start`] to handle
-/// the power save block
-struct NoSleepHandle {
-    handle: u32,
-}
-
-impl NoSleepHandle {
-    /// Stop blocking the system from entering power save mode
-    pub fn stop(self: &NoSleepHandle) -> Result<()> {
-        unsafe {
-            sys::stop(self.handle);
-        }
-        Ok(())
-    }
-}
 pub struct NoSleep {
     // The unblock handle
-    no_sleep_handle: Option<NoSleepHandle>,
+    no_sleep_handle: Option<u32>,
 }
 
-impl NoSleep {
-    pub fn new() -> Result<NoSleep> {
+impl NoSleepTrait for NoSleep {
+    fn new() -> Result<NoSleep, NoSleepError> {
         Ok(NoSleep {
             no_sleep_handle: None,
         })
     }
 
-    /// Blocks the system from entering low-power (sleep) mode by
-    /// making a synchronous call to the macOS `IOPMAssertionCreateWithName` system call.
-    /// If [`self::stop`] is not called, then he lock will be cleaned up
-    /// when the process PID exits.
-    pub fn start(&mut self, nosleep_type: NoSleepType) -> Result<()> {
-        // Clear any previous handles held
+    fn prevent_display_sleep(&mut self) -> Result<(), NoSleepError> {
         self.stop()?;
 
         let mut handle = 0u32;
-        let ret = unsafe { sys::start(nosleep_ns_string(&nosleep_type).deref(), &mut handle) };
+        let ret = unsafe { sys::start(NSString::from_str("PreventUserIdleDisplaySleep").deref(), &mut handle) };
         if ret != 0 {
-            return PreventPowerSaveModeSnafu {
-                option: nosleep_type,
-            }
-            .fail();
+            return Err(NoSleepError::PreventDisplaySleep {
+                reason: ret.to_string()
+            });
         }
-        self.no_sleep_handle = Some(NoSleepHandle { handle });
+        self.no_sleep_handle = Some(handle);
         Ok(())
     }
 
-    /// Stop blocking the system from entering power save mode
-    pub fn stop(&self) -> Result<()> {
+    fn prevent_system_sleep(&mut self) -> Result<(), NoSleepError> {
+        self.stop()?;
+
+        let mut handle = 0u32;
+        let ret = unsafe { sys::start(NSString::from_str("PreventUserIdleSystemSleep").deref(), &mut handle) };
+        if ret != 0 {
+            return Err(NoSleepError::PreventSystemSleep {
+                reason: ret.to_string()
+            });
+        }
+        self.no_sleep_handle = Some(handle);
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<(), NoSleepError> {
         if let Some(handle) = &self.no_sleep_handle {
-            handle.stop()?;
+            unsafe {
+                sys::stop(*handle);
+            }
+            self.no_sleep_handle.take();
         }
         Ok(())
     }
 }
 
-/// TODO: Check if this still fits within the API
-/// Checks if the power save block is active
-/// for a provided [`u32`] from [`start`]
-// pub fn is_started(no_sleep_handle: u32) -> bool {
-//     unsafe { sys::isStarted(no_sleep_handle) }
-// }
-
 #[cfg(test)]
 mod tests {
-    use crate::{NoSleep, NoSleepType};
+    use nosleep_types::NoSleepTrait;
+
+    use super::NoSleep;
 
     #[test]
     fn test_start() {
         let mut nosleep = NoSleep::new().unwrap();
         nosleep
-            .start(NoSleepType::PreventUserIdleDisplaySleep)
+            .prevent_display_sleep()
             .unwrap();
     }
 
@@ -122,17 +89,8 @@ mod tests {
     fn test_stop() {
         let mut nosleep = NoSleep::new().unwrap();
         nosleep
-            .start(NoSleepType::PreventUserIdleDisplaySleep)
+            .prevent_display_sleep()
             .unwrap();
         nosleep.stop().unwrap();
     }
-
-    // #[test]
-    // fn test_is_started() {
-    //     assert_eq!(false, is_started(1));
-    //     let ret = start(NoSleepType::PreventUserIdleDisplaySleep).unwrap();
-    //     assert_eq!(true, is_started(ret));
-    //     stop(ret);
-    //     assert_eq!(false, is_started(ret));
-    // }
 }

--- a/nosleep-mac-sys/src/lib.rs
+++ b/nosleep-mac-sys/src/lib.rs
@@ -36,10 +36,15 @@ impl NoSleepTrait for NoSleep {
         self.stop()?;
 
         let mut handle = 0u32;
-        let ret = unsafe { sys::start(NSString::from_str("PreventUserIdleDisplaySleep").deref(), &mut handle) };
+        let ret = unsafe {
+            sys::start(
+                NSString::from_str("PreventUserIdleDisplaySleep").deref(),
+                &mut handle,
+            )
+        };
         if ret != 0 {
-            return Err(NoSleepError::PreventDisplaySleep {
-                reason: ret.to_string()
+            return Err(NoSleepError::PreventSleep {
+                reason: ret.to_string(),
             });
         }
         self.no_sleep_handle = Some(handle);
@@ -50,10 +55,15 @@ impl NoSleepTrait for NoSleep {
         self.stop()?;
 
         let mut handle = 0u32;
-        let ret = unsafe { sys::start(NSString::from_str("PreventUserIdleSystemSleep").deref(), &mut handle) };
+        let ret = unsafe {
+            sys::start(
+                NSString::from_str("PreventUserIdleSystemSleep").deref(),
+                &mut handle,
+            )
+        };
         if ret != 0 {
-            return Err(NoSleepError::PreventSystemSleep {
-                reason: ret.to_string()
+            return Err(NoSleepError::PreventSleep {
+                reason: ret.to_string(),
             });
         }
         self.no_sleep_handle = Some(handle);
@@ -80,17 +90,13 @@ mod tests {
     #[test]
     fn test_start() {
         let mut nosleep = NoSleep::new().unwrap();
-        nosleep
-            .prevent_display_sleep()
-            .unwrap();
+        nosleep.prevent_display_sleep().unwrap();
     }
 
     #[test]
     fn test_stop() {
         let mut nosleep = NoSleep::new().unwrap();
-        nosleep
-            .prevent_display_sleep()
-            .unwrap();
+        nosleep.prevent_display_sleep().unwrap();
         nosleep.stop().unwrap();
     }
 }

--- a/nosleep-mac-sys/src/lib.rs
+++ b/nosleep-mac-sys/src/lib.rs
@@ -88,9 +88,15 @@ mod tests {
     use super::NoSleep;
 
     #[test]
-    fn test_start() {
+    fn test_prevent_display_sleep() {
         let mut nosleep = NoSleep::new().unwrap();
         nosleep.prevent_display_sleep().unwrap();
+    }
+
+    #[test]
+    fn test_prevent_system_sleep() {
+        let mut nosleep = NoSleep::new().unwrap();
+        nosleep.prevent_system_sleep().unwrap();
     }
 
     #[test]

--- a/nosleep-nix/Cargo.toml
+++ b/nosleep-nix/Cargo.toml
@@ -2,16 +2,16 @@
 name = "nosleep-nix"
 description = "Block power save mode cross platform"
 authors = ["Peter Evers"]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
-rust-version = "1.57"
 homepage = "https://github.com/pevers/nosleep"
 repository = "https://github.com/pevers/nosleep"
 license = "MIT"
-keywords = ["nosleep", "powersave", "caffeine"]
+keywords = ["nosleep", "powersave", "caffeine", "prevent-sleep", "prevent-display-lock", "prevent-system-lock"]
 readme = "README.md"
 
 [dependencies]
-nosleep-types = { path = "../nosleep-types", version = "0.2.0" }
+nosleep-types = { path = "../nosleep-types", version = "0.3.0" }
+
+[target.'cfg(unix)'.dependencies]
 dbus = "0.9.5"
-snafu = "0.7.0"

--- a/nosleep-nix/Cargo.toml
+++ b/nosleep-nix/Cargo.toml
@@ -12,6 +12,4 @@ readme = "README.md"
 
 [dependencies]
 nosleep-types = { path = "../nosleep-types", version = "0.3.0" }
-
-[target.'cfg(unix)'.dependencies]
 dbus = "0.9.5"

--- a/nosleep-nix/src/lib.rs
+++ b/nosleep-nix/src/lib.rs
@@ -78,12 +78,12 @@ impl NoSleep {
         let response = self
             .d_bus
             .send_with_reply_and_block(msg, std::time::Duration::from_millis(5000))
-            .map_err(|e| NoSleepError::DBus {
+            .map_err(|e| NoSleepError::PreventSleep {
                 reason: e.to_string(),
             })?;
         match response.get1::<u32>() {
             Some(handle) => Ok(NoSleepHandle { handle, api: *api }),
-            None => Err(NoSleepError::DBus {
+            None => Err(NoSleepError::PreventSleep {
                 reason: "Invalid message or type".to_string(),
             }),
         }

--- a/nosleep-nix/src/lib.rs
+++ b/nosleep-nix/src/lib.rs
@@ -286,9 +286,19 @@ mod tests {
     // Can only run with an active Gnome Session
     #[test]
     #[ignore]
-    fn test_start() {
+    fn test_prevent_system_sleep() {
         let mut nosleep = NoSleep::new().unwrap();
         nosleep.prevent_system_sleep().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(2000));
+        nosleep.stop().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(2000));
+    }
+
+    #[test]
+    #[ignore]
+    fn test_prevent_display_sleep() {
+        let mut nosleep = NoSleep::new().unwrap();
+        nosleep.prevent_display_sleep().unwrap();
         std::thread::sleep(std::time::Duration::from_millis(2000));
         nosleep.stop().unwrap();
         std::thread::sleep(std::time::Duration::from_millis(2000));

--- a/nosleep-types/Cargo.toml
+++ b/nosleep-types/Cargo.toml
@@ -2,19 +2,14 @@
 name = "nosleep-types"
 description = "Block power save mode cross platform"
 authors = ["Peter Evers"]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
-rust-version = "1.57"
 homepage = "https://github.com/pevers/nosleep"
 repository = "https://github.com/pevers/nosleep"
 license = "MIT"
-keywords = ["nosleep", "powersave", "caffeine"]
+keywords = ["nosleep", "powersave", "caffeine", "prevent-sleep", "prevent-display-lock", "prevent-system-lock"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 snafu = "0.7.0"
-serde = { version = "1.0.137", features = ["derive"], optional = true }
-
-[features]
-serde = ["dep:serde"]

--- a/nosleep-types/src/lib.rs
+++ b/nosleep-types/src/lib.rs
@@ -12,6 +12,11 @@ pub enum NoSleepError {
     {
         reason: String,
     },
+    #[snafu(display("DBus error: {:?}", reason))]
+    DBus
+    {
+        reason: String,
+    },
     #[snafu(display("Could not stop lock: {:?}", reason))]
     StopLock
     {

--- a/nosleep-types/src/lib.rs
+++ b/nosleep-types/src/lib.rs
@@ -1,13 +1,37 @@
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use snafu::Snafu;
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NoSleepType {
+#[derive(Debug, Snafu)]
+pub enum NoSleepError {
+    #[snafu(display("Could not prevent display sleep: {:?}", reason))]
+    PreventDisplaySleep 
+    {
+        reason: String,
+    },
+    #[snafu(display("Could not prevent system sleep: {:?}", reason))]
+    PreventSystemSleep
+    {
+        reason: String,
+    },
+    #[snafu(display("Could not stop lock: {:?}", reason))]
+    StopLock
+    {
+        reason: String,
+    },
+}
+
+pub trait NoSleepTrait {
+    fn new() -> Result<Self, NoSleepError>
+    where
+        Self: Sized;
+
     /// Prevents the display from dimming automatically.
     /// For example: playing a video.
-    PreventUserIdleDisplaySleep,
+    fn prevent_display_sleep(&mut self) -> Result<(), NoSleepError>;
+
     /// Prevents the system from sleeping automatically due to a lack of user activity.
     /// For example: downloading a file in the background.
-    PreventUserIdleSystemSleep,
+    fn prevent_system_sleep(&mut self) -> Result<(), NoSleepError>;
+
+    /// Cancels any previous call to `prevent_display_sleep` or `prevent_system_sleep`.
+    fn stop(&mut self) -> Result<(), NoSleepError>;
 }

--- a/nosleep-types/src/lib.rs
+++ b/nosleep-types/src/lib.rs
@@ -3,25 +3,13 @@ use snafu::Snafu;
 #[derive(Debug, Snafu)]
 pub enum NoSleepError {
     #[snafu(display("Could not initialize: {:?}", reason))]
-    Init
-    {
-        reason: String,
-    },
+    Init { reason: String },
     #[snafu(display("Could not prevent sleep: {:?}", reason))]
-    PreventSleep
-    {
-        reason: String,
-    },
+    PreventSleep { reason: String },
     #[snafu(display("DBus error: {:?}", reason))]
-    DBus
-    {
-        reason: String,
-    },
+    DBus { reason: String },
     #[snafu(display("Could not stop lock: {:?}", reason))]
-    StopLock
-    {
-        reason: String,
-    },
+    StopLock { reason: String },
 }
 
 pub trait NoSleepTrait {

--- a/nosleep-types/src/lib.rs
+++ b/nosleep-types/src/lib.rs
@@ -7,13 +7,8 @@ pub enum NoSleepError {
     {
         reason: String,
     },
-    #[snafu(display("Could not prevent display sleep: {:?}", reason))]
-    PreventDisplaySleep 
-    {
-        reason: String,
-    },
-    #[snafu(display("Could not prevent system sleep: {:?}", reason))]
-    PreventSystemSleep
+    #[snafu(display("Could not prevent sleep: {:?}", reason))]
+    PreventSleep
     {
         reason: String,
     },

--- a/nosleep-types/src/lib.rs
+++ b/nosleep-types/src/lib.rs
@@ -2,6 +2,11 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 pub enum NoSleepError {
+    #[snafu(display("Could not initialize: {:?}", reason))]
+    Init
+    {
+        reason: String,
+    },
     #[snafu(display("Could not prevent display sleep: {:?}", reason))]
     PreventDisplaySleep 
     {

--- a/nosleep-windows/Cargo.toml
+++ b/nosleep-windows/Cargo.toml
@@ -8,13 +8,13 @@ rust-version = "1.57"
 homepage = "https://github.com/pevers/nosleep"
 repository = "https://github.com/pevers/nosleep"
 license = "MIT"
-keywords = ["nosleep", "powersave", "caffeine"]
+keywords = ["nosleep", "powersave", "caffeine", "prevent-sleep", "prevent-display-lock", "prevent-system-lock"]
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nosleep-types = { path = "../nosleep-types", version = "0.2.0" }
+nosleep-types = { path = "../nosleep-types", version = "0.2.1" }
 snafu = "0.7.0"
 
 [dependencies.windows]

--- a/nosleep-windows/Cargo.toml
+++ b/nosleep-windows/Cargo.toml
@@ -2,9 +2,8 @@
 name = "nosleep-windows"
 description = "Block power save mode cross platform"
 authors = ["Peter Evers"]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
-rust-version = "1.57"
 homepage = "https://github.com/pevers/nosleep"
 repository = "https://github.com/pevers/nosleep"
 license = "MIT"
@@ -14,11 +13,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nosleep-types = { path = "../nosleep-types", version = "0.2.1" }
+nosleep-types = { path = "../nosleep-types", version = "0.3.0" }
 snafu = "0.7.0"
 
 [dependencies.windows]
-version = "0.36.1"
+version = "0.54.0"
 features = [
     "Win32_System_Power",
     "Win32_Foundation",

--- a/nosleep/Cargo.toml
+++ b/nosleep/Cargo.toml
@@ -2,26 +2,28 @@
 name = "nosleep"
 description = "Block power save mode cross platform"
 authors = ["Peter Evers"]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
-rust-version = "1.57"
 homepage = "https://github.com/pevers/nosleep"
 repository = "https://github.com/pevers/nosleep"
 license = "MIT"
-keywords = ["nosleep", "powersave", "caffeine"]
+keywords = ["nosleep", "powersave", "caffeine", "prevent-sleep", "prevent-display-lock", "prevent-system-lock"]
 readme = "../README.md"
 
 [dependencies]
-nosleep-types = { path = "../nosleep-types", version = "0.2.1" }
+nosleep-types = { path = "../nosleep-types", version = "0.3.0" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-nosleep-mac-sys = { path = "../nosleep-mac-sys", version = "0.2.1" }
+nosleep-mac-sys = { path = "../nosleep-mac-sys", version = "0.3.0" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nosleep-nix = { path = "../nosleep-nix", version = "0.2.1" }
+nosleep-nix = { path = "../nosleep-nix", version = "0.3.0" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-nosleep-windows = { path = "../nosleep-windows", version = "0.2.1" }
+nosleep-windows = { path = "../nosleep-windows", version = "0.3.0" }
+
+[target.'cfg(target_os = "ios")'.dependencies]
+nosleep-ios = { path = "../nosleep-ios-sys", version = "0.3.0" }
 
 [features]
 serde = ["nosleep-types/serde"]

--- a/nosleep/Cargo.toml
+++ b/nosleep/Cargo.toml
@@ -21,9 +21,3 @@ nosleep-nix = { path = "../nosleep-nix", version = "0.3.0" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 nosleep-windows = { path = "../nosleep-windows", version = "0.3.0" }
-
-[target.'cfg(target_os = "ios")'.dependencies]
-nosleep-ios = { path = "../nosleep-ios-sys", version = "0.3.0" }
-
-[features]
-serde = ["nosleep-types/serde"]

--- a/nosleep/src/lib.rs
+++ b/nosleep/src/lib.rs
@@ -7,7 +7,7 @@
 //! # use nosleep::*;
 //! # fn main() -> Result<(), Box<dyn Error>> {
 //!    let nosleep = NoSleep::new()?;
-//!    nosleep.start(NoSleepType::PreventUserIdleDisplaySleep)?;
+//!    nosleep.prevent_display_sleep()?;
 //!    // Depending on the platform, the block will hold
 //!    // until either nosleep will be dropped (Linux)
 //!    // or the process exits (macOS) or you manually
@@ -15,8 +15,6 @@
 //! #  Ok(())
 //! # }
 //! ```
-
-pub use nosleep_types::NoSleepType;
 
 #[cfg(target_os = "macos")]
 pub use nosleep_mac_sys::*;
@@ -29,14 +27,14 @@ pub use nosleep_windows::*;
 
 #[cfg(test)]
 mod tests {
+    use nosleep_types::NoSleepTrait;
+
     use crate::*;
 
     #[test]
     fn test_block_platform_agnostic() {
         let mut nosleep = NoSleep::new().unwrap();
-        nosleep
-            .start(NoSleepType::PreventUserIdleDisplaySleep)
-            .unwrap();
+        nosleep.prevent_display_sleep().unwrap();
         std::thread::sleep(std::time::Duration::from_millis(2000));
         nosleep.stop().unwrap();
     }


### PR DESCRIPTION
SImplify API by making method names more explicit.

- Removed enum `NoSleepType` since the types are not really cross platform, replaced them with explicit method calls on the trait
- Made errors more generic with a string type, instead of tying it to system specific traces

Tested on:

- [x] MacOS
- [x] Windows
- [ ] Linux
